### PR TITLE
Improve build performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ yarn install @mietz-gmbh/lambda-build-js
 ## Build Lambda
 
 ```bash
-yarn yarn build-lambda [function_name] [--logging] [--watch]
+yarn build-lambda [function_name] [--logging] [--watch]
 ```
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # lambda-build-js
 NPM package to build node.js AWS lambda functions.
+
+# Get Started
+
+## Install
+
+```bash
+yarn install @mietz-gmbh/lambda-build-js
+```
+
+## Build Lambda
+
+```bash
+yarn yarn build-lambda [function_name] [--logging] [--watch]
+```
+
+# Configuration
+
+Create a file called `lambda-build.config.js` with a default export (`module.exports`).
+
+You can specify webpacks `alias` and `externals`.
+
+```js
+module.exports = {
+  alias: {
+    pg: 'pg.js'
+  },
+  externals: [
+    'aws-sdk',
+  ]
+}
+```


### PR DESCRIPTION
- Exclude node modules during build
- Run single Webpack compile

For maximum performance, we should also add the `pg` package to Webpack's `externals`, but doing so seems to break our custom resolve alias. @marvin-kolja Any idea how to do this? Should we just make a custom npm package?

| Project            | Before | After  | Excluding pg |
|--------------------|--------|--------|--------------|
| app-terraform-api  | 39.81s | 2.535s | 1.3575s      |
| app-terraform-user | 3.385s | 2.015s | 1.1775s      |