### PR TITLE
Allow to specify the logging level of the build functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # lambda-build-js
+
 NPM package to build node.js AWS lambda functions.
 
 # Get Started
@@ -12,8 +13,14 @@ yarn install @mietz-gmbh/lambda-build-js
 ## Build Lambda
 
 ```bash
-yarn build-lambda [function_name] [--logging] [--watch]
+yarn build-lambda [function_name] [--logging] [--watch] [--loggingLevel=[debug|info|warn|error]]
 ```
+
+|flag|default| description                                                                                                                         |
+|---|---|-------------------------------------------------------------------------------------------------------------------------------------|
+|`--logging`|`false`| enable logging                                                                                                                      |
+|`--watch`|`false`| enable watch mode                                                                                                                   |
+|`--loggingLevel`|`debug`| sets the logging level</br></br>**you must enable logging for this option to work!**</br></br>valid values are: `debug` `info` `warn` `error` |
 
 # Configuration
 
@@ -23,11 +30,11 @@ You can specify webpacks `alias` and `externals`.
 
 ```js
 module.exports = {
-  alias: {
-    pg: 'pg.js'
-  },
-  externals: [
-    'aws-sdk',
-  ]
+    alias: {
+        pg: 'pg.js'
+    },
+    externals: [
+        'aws-sdk',
+    ]
 }
 ```


### PR DESCRIPTION
**Allows the developer to set the logging level using the `--loggingLevel` flag**

- Instead of removing all logs (using the terser plugins compress `drop_console` option) it now uses the `pure_funcs` compress option to remove specific console functions.